### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,9 +136,9 @@ and based in San Fran.
 .. _pyenv: https://github.com/yyuu/pyenv
 .. _Sphinx: http://sphinx-doc.org/
 .. _`Read the Docs`: https://github.com/snide/sphinx_rtd_theme
-.. _`Read the Docs site`: https://griffin.readthedocs.org
-.. _`usage`: http://griffin.readthedocs.org/en/latest/usage.html
-.. _`How to Contribute`: http://griffin.readthedocs.org/en/latest/contributing.html
+.. _`Read the Docs site`: https://griffin.readthedocs.io
+.. _`usage`: https://griffin.readthedocs.io/en/latest/usage.html
+.. _`How to Contribute`: https://griffin.readthedocs.io/en/latest/contributing.html
 .. _`webchat`: http://webchat.freenode.net?channels=%23ramlfications&uio=ND10cnVlJjk9dHJ1ZQb4
 .. _`econchick`: https://github.com/econchick
 .. _`Twitter`: https://twitter.com/roguelynn

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -34,7 +34,7 @@ CLI
 
         A ``ini`` configuration file for parsing RAML.  See the `ramlfications \
         documentation \
-        <https://ramlfications.readthedocs.org/en/latest/config.html>`_ \
+        <https://ramlfications.readthedocs.io/en/latest/config.html>`_ \
         for more information.
 
     .. program:: build
@@ -54,7 +54,7 @@ Core
 
     .. py:attribute:: api
 
-        The API parsed by `ramlfications <https://ramlfications.readthedocs.org/en/latest>`_.
+        The API parsed by `ramlfications <https://ramlfications.readthedocs.io/en/latest>`_.
 
     .. py:attribute:: metadata
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -22,7 +22,7 @@ About
 It’s tested on Python 2.6, 2.7, 3.3+, and PyPy. Both Linux and OS X are supported.
 
 
-.. _`Read the Docs`: https://griffin.readthedocs.org/
+.. _`Read the Docs`: https://griffin.readthedocs.io/
 .. _`GitHub`:  https://github.com/spotify/griffin/
 .. _`RAML`: http://raml.org
-.. _`RAMLfications`: https://ramlfications.readthedocs.org
+.. _`RAMLfications`: https://ramlfications.readthedocs.io

--- a/griffin/__init__.py
+++ b/griffin/__init__.py
@@ -9,7 +9,7 @@ __version__ = '0.0.1.dev1'
 
 
 __email__ = "lynn@spotify.com"
-__uri__ = "https://griffin.readthedocs.org"
+__uri__ = "https://griffin.readthedocs.io"
 __description__ = "A RAML documentation generator in Python"
 
 __license__ = "Apache 2.0"

--- a/griffin/cli.py
+++ b/griffin/cli.py
@@ -116,7 +116,7 @@ def build(ramlfile, config, output=None, ramlconfig=None):
     :param str output: output of HTML files
     :param str ramlconfig: configuration for RAML parsing.  See \
         `ramlfications documentation \
-        <https://ramlfications.readthedocs.org/en/latest/config.html>`_ \
+        <https://ramlfications.readthedocs.io/en/latest/config.html>`_ \
         for more information.
     """
     # parse out RAML file & create context for templates

--- a/griffin/core.py
+++ b/griffin/core.py
@@ -15,7 +15,7 @@ class APIContext(object):
     Context object of the parsed API.
 
     :param api: The API parsed by \
-        `ramlfications <https://ramlfications.readthedocs.org/en/latest>`_.
+        `ramlfications <https://ramlfications.readthedocs.io/en/latest>`_.
     """
     def __init__(self, api):
         self.api = api
@@ -209,7 +209,7 @@ def create_context(ramlfile, ramlconfig=None):
 
     :param str ramlfile:  RAML file to parse
     :param str ramlconfig: config file for RAML (see ``ramlfications`` \
-        `docs <https://ramlfications.readthedocs.org/en/latest/config.html>`_)
+        `docs <https://ramlfications.readthedocs.io/en/latest/config.html>`_)
     :rtype: :py:class:`.APIContext` object
     """
     api = ramlfications.parse(ramlfile, ramlconfig)


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
